### PR TITLE
Fix context for device list and add pagination

### DIFF
--- a/core/templates/core/device_list.html
+++ b/core/templates/core/device_list.html
@@ -37,8 +37,40 @@
                     <a href="{% url 'device_delete' device.pk %}" class="btn btn-sm btn-danger">Usuń</a>
                 </td>
             </tr>
+        {% empty %}
+            <tr><td colspan="6">Brak urządzeń.</td></tr>
         {% endfor %}
         </tbody>
     </table>
+
+    <nav aria-label="Page navigation">
+        <ul class="pagination">
+            {% if page_obj.has_previous %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+                        <span aria-hidden="true">&laquo;</span>
+                    </a>
+                </li>
+            {% else %}
+                <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+            {% endif %}
+            {% for num in page_obj.paginator.page_range %}
+                {% if page_obj.number == num %}
+                    <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+                {% else %}
+                    <li class="page-item"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+                {% endif %}
+            {% endfor %}
+            {% if page_obj.has_next %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+                        <span aria-hidden="true">&raquo;</span>
+                    </a>
+                </li>
+            {% else %}
+                <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            {% endif %}
+        </ul>
+    </nav>
 
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -14,18 +14,22 @@ from django.core.paginator import Paginator
 
 @login_required
 def device_list(request):
+    """Display a paginated list of devices."""
     # Nasz "znacznik" do udowodnienia, że ten kod się uruchamia.
     # Używam aktualnej daty i godziny, żeby był unikalny.
     test_message = "Test z 17 czerwca, godz. 15:10"
 
-    # Prosta logika: pobierz wszystkie urządzenia
-    all_devices = Device.objects.all().order_by('id')
+    all_devices = Device.objects.all().order_by("id")
+    paginator = Paginator(all_devices, 10)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
 
     context = {
-        'devices': all_devices,
-        'test_message_from_view': test_message,
+        "devices": page_obj,
+        "page_obj": page_obj,
+        "test_message_from_view": test_message,
     }
-    return render(request, 'core/device_list.html', context)
+    return render(request, "core/device_list.html", context)
 
 @login_required
 def device_add(request):
@@ -78,21 +82,6 @@ def device_stats(request):
 def device_stats_page(request):
     return render(request, 'core/device_stats.html')
 
-@login_required
-def device_list(request):
-    devices = Device.objects.all()
-    return render(request, 'core/device_list.html', {'devices': devices})
-
-@login_required
-def device_add(request):
-    if request.method == 'POST':
-        form = DeviceForm(request.POST)
-        if form.is_valid():
-            form.save()
-            return redirect('device_list')
-    else:
-        form = DeviceForm()
-    return render(request, 'core/device_form.html', {'form': form})
 
 @login_required
 def device_edit(request, pk):


### PR DESCRIPTION
## Summary
- ensure `device_list` view provides context correctly
- remove duplicate view definitions
- paginate devices and show navigation links

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685186636a48832f846e58fd1c3ab102