### PR TITLE
Fix context for device list and add pagination

### DIFF
--- a/core/templates/core/device_list.html
+++ b/core/templates/core/device_list.html
@@ -1,14 +1,13 @@
 {% extends "core/base.html" %}
 
 {% block content %}
-    <div class="alert alert-info" role="alert">
-<pre>test_message_from_view = {{ test_message_from_view|default:"(brak w kontekście)" }}</pre>
-    </div>
-    <div id="MY-MARKER">XYZ</div>
-
-    <a href="{% url 'device_list' %}" class="btn btn-secondary mb-3">Powrót do listy DUPY</a>
     <h2>Lista urządzeń</h2>
     <div class="mb-3">
+        {% if show_all %}
+            <a href="{% url 'device_list' %}" class="btn btn-secondary btn-sm">Włącz paginację</a>
+        {% else %}
+            <a href="?all=1" class="btn btn-secondary btn-sm">Pokaż wszystkie</a>
+        {% endif %}
         <a href="{% url 'device_add' %}" class="btn btn-primary btn-sm ms-2">Dodaj urządzenie</a>
         <a href="{% url 'device_stats_page' %}" class="btn btn-info btn-sm ms-2">Statystyki</a>
     </div>
@@ -37,8 +36,42 @@
                     <a href="{% url 'device_delete' device.pk %}" class="btn btn-sm btn-danger">Usuń</a>
                 </td>
             </tr>
+        {% empty %}
+            <tr><td colspan="6">Brak urządzeń.</td></tr>
         {% endfor %}
         </tbody>
     </table>
+
+    {% if page_obj %}
+    <nav aria-label="Page navigation">
+        <ul class="pagination">
+            {% if page_obj.has_previous %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}" aria-label="Previous">
+                        <span aria-hidden="true">&laquo;</span>
+                    </a>
+                </li>
+            {% else %}
+                <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+            {% endif %}
+            {% for num in page_obj.paginator.page_range %}
+                {% if page_obj.number == num %}
+                    <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+                {% else %}
+                    <li class="page-item"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+                {% endif %}
+            {% endfor %}
+            {% if page_obj.has_next %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}" aria-label="Next">
+                        <span aria-hidden="true">&raquo;</span>
+                    </a>
+                </li>
+            {% else %}
+                <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
 
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -10,22 +10,30 @@ from .models import Device
 import matplotlib.pyplot as plt
 from django.core.paginator import Paginator
 
-# w pliku core/views.py
+# Views
 
 @login_required
 def device_list(request):
-    # Nasz "znacznik" do udowodnienia, że ten kod się uruchamia.
-    # Używam aktualnej daty i godziny, żeby był unikalny.
-    test_message = "Test z 17 czerwca, godz. 15:10"
+    """Display the device list with optional pagination."""
 
-    # Prosta logika: pobierz wszystkie urządzenia
-    all_devices = Device.objects.all().order_by('id')
+    all_devices = Device.objects.all().order_by("id")
+    show_all = request.GET.get("all") == "1"
+
+    if show_all:
+        devices = all_devices
+        page_obj = None
+    else:
+        paginator = Paginator(all_devices, 10)
+        page_number = request.GET.get("page")
+        page_obj = paginator.get_page(page_number)
+        devices = page_obj
 
     context = {
-        'devices': all_devices,
-        'test_message_from_view': test_message,
+        "devices": devices,
+        "page_obj": page_obj,
+        "show_all": show_all,
     }
-    return render(request, 'core/device_list.html', context)
+    return render(request, "core/device_list.html", context)
 
 @login_required
 def device_add(request):
@@ -78,21 +86,6 @@ def device_stats(request):
 def device_stats_page(request):
     return render(request, 'core/device_stats.html')
 
-@login_required
-def device_list(request):
-    devices = Device.objects.all()
-    return render(request, 'core/device_list.html', {'devices': devices})
-
-@login_required
-def device_add(request):
-    if request.method == 'POST':
-        form = DeviceForm(request.POST)
-        if form.is_valid():
-            form.save()
-            return redirect('device_list')
-    else:
-        form = DeviceForm()
-    return render(request, 'core/device_form.html', {'form': form})
 
 @login_required
 def device_edit(request, pk):


### PR DESCRIPTION
## Summary
- ensure `device_list` view provides context correctly
- remove duplicate view definitions
- paginate devices and show navigation links
- add toggle button to disable pagination
- remove leftover debug text and 'DUPY' string

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685186636a48832f846e58fd1c3ab102